### PR TITLE
Get variables LESS_TERMCAP_* from lesskey file

### DIFF
--- a/main.c
+++ b/main.c
@@ -110,8 +110,8 @@ main(argc, argv)
      * Command line arguments override environment arguments.
      */
     is_tty = isatty(1);
-    get_term();
-    init_cmds();
+    init_cmds();    /* Read the lesskey file, e.g. ~/.less */ 
+    get_term();     /* Get the LESS_TERMCAP_* from lesskey file or from environment */
     init_charset();
     init_line();
     init_cmdhist();


### PR DESCRIPTION
Fix issue https://github.com/rivy/less/issues/1

The command "less" skips the variables "LESS_TERMCAP_*" defined in the lesskey file (e.g. ~/.less).

This is because, the function "main()" retrieves the variables "LESS_TERMCAP_*"
before loading of the lesskey file.

This fix inverts two lines in order to load the lesskey file
before getting/initializing the "LESS_TERMCAP_*" variables.

I explain that in details on this site:
https://unix.stackexchange.com/a/377221/13999