### PR TITLE
Added copy command check to mingw makefile

### DIFF
--- a/Makefile.win.mingw
+++ b/Makefile.win.mingw
@@ -24,7 +24,11 @@ LIBS =
 EXEEXT = .exe
 O = o
 
-CP = copy
+CP = $(shell command -v cp >/dev/null 2>&1 && echo 'cp')
+
+ifneq ($(CP),cp)
+	CP = copy
+endif
 
 DEFINETYPE = wn
 OBJDEP = defines.h less.h


### PR DESCRIPTION
I built this project using msys2 and this tripped me up, so I figured I'd make this automatic. If for some reason the shell command to check for 'cp' does not end up returning 'cp' (by using a conditional echo), it will switch over to the copy command.