### PR TITLE
Fixes Makefile.win for msys2 [dev]

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -74,6 +74,7 @@ CFLAGS_ARCH_64 := -m64
 CFLAGS_DEBUG_true := -DDEBUG -O0 -g
 CFLAGS_DEBUG_false := -DNDEBUG -O3
 CFLAGS_VERBOSE_true := -v
+CFLAGS_check := -v
 CFLAGS_machine := -dumpmachine
 CFLAGS_v := --version
 CPPFLAGS := $()
@@ -340,8 +341,7 @@ $(call %debug_var,LIB)
 ####
 
 # detect ${CC}
-CC_check_flags := $(if $(filter cl,${CC_ID}),,-v)
-ifeq (,$(shell "${CC}" ${CC_check_flags} >${devnull} 2>&1 && echo ${CC} present))
+ifeq (,$(shell "${CC}" ${CFLAGS_check} >${devnull} 2>&1 && echo ${CC} present))
 $(call %error,Missing required compiler (`${CC}`))
 endif
 

--- a/Makefile.win
+++ b/Makefile.win
@@ -180,19 +180,6 @@ MAKEFLAGS_debug ?= $(if $(findstring d,${MAKEFLAGS}),true,false)## Makefile debu
 
 #### End of system configuration section. ####
 
-OSID := $(or $(and $(filter .exe,$(patsubst %.exe,.exe,$(subst $() $(),_,${SHELL}))),$(filter win,${OS:Windows_NT=win})),nix)## OSID == [nix,win]
-
-# for Windows OS, set SHELL to `%ComSpec%` or `cmd` (note: environment/${OS}=="Windows_NT" for XP, 2000, Vista, 7, 10 ...)
-# * `make` may otherwise use an incorrect shell (eg, `bash`), if found; "syntax error: unexpected end of file" error output is indicative
-ifeq (${OSID},win)
-# use case and location fallbacks; note: assumes *no spaces* within ${ComSpec}, ${SystemRoot}, or ${windir}
-COMSPEC := $(or ${ComSpec},${COMSPEC},${comspec})
-SystemRoot := $(or ${SystemRoot},${SYSTEMROOT},${systemroot},${windir})
-SHELL := $(firstword $(wildcard ${COMSPEC} ${SystemRoot}/System32/cmd.exe) cmd)
-endif
-
-####
-
 falsey := false 0 f n no off
 false := $()
 true := true

--- a/Makefile.win
+++ b/Makefile.win
@@ -354,7 +354,7 @@ $(call %debug_var,LIB)
 
 # detect ${CC}
 ifeq (,$(shell "${CC}" ${CFLAGS_check} >${devnull} 2>&1 && echo ${CC} present))
-$(call %error,Missing required compiler (`${CC}`))
+$(if $(MSYSCON),,$(call %error,Missing required compiler (`${CC}`)))
 endif
 
 ifeq (${SPACE},$(findstring ${SPACE},${makefile_abs_path}))
@@ -655,7 +655,7 @@ $(call %debug_var,OBJ_files)
 
 ${AUX_targets}: %${EXEEXT}: %.${O} version.${O} ${makefile_abs_path} | ${OUT_bin}
 	${LD} ${LDFLAGS} "$<" "version.${O}" ${LIBS} ${LD_o}"$@"
-	$(if $(and ${STRIP},$(call %is_falsey,${DEBUG})),${STRIP} "$@",)
+	$(if $(and ${STRIP},$(call %is_falsey,${DEBUG})),${STRIP} "$(@:.exe=).exe",)
 	@${ECHO} $(call %shell_quote,$(call %success_text,made '$@'.))
 
 ${OBJ_files}: ${OBJ_deps} | ${OUT_obj}
@@ -712,7 +712,7 @@ veryclean: realclean
 
 ${PROJECT_TARGET}: ${OBJ_files} ${makefile_abs_path} | ${OUT_bin}
 	${LD} ${LDFLAGS} ${LD_o}"$@" $(addprefix ",$(addsuffix ",${OBJ_files})) ${LIBS}
-	$(if $(and ${STRIP},$(call %is_falsey,${DEBUG})),${STRIP} "$@",)
+	$(if $(and ${STRIP},$(call %is_falsey,${DEBUG})),${STRIP} "$(@:.exe=).exe",)
 	@${ECHO} $(call %shell_quote,$(call %success_text,made '$@'.))
 
 ${OUT_obj}/%.${O}: ${SRC_DIR}/%.c ${makefile_abs_path} | ${OUT_obj}

--- a/Makefile.win
+++ b/Makefile.win
@@ -155,19 +155,37 @@ LDFLAGS_ARCH_32 := /machine:I386
 ## /ignore:4254 :: suppress "merging sections with different attributes" warning (LNK4254)
 LDFLAGS_VC6_true := /ignore:4254
 
+CC_${CC_ID}_e := /Fe
+CC_${CC_ID}_o := /Fo
+LD_${CC_ID}_o := /out:
+
+O_${CC_ID} := obj
+
 LIBS := user32.lib
 endif ## `cl` (MSVC)
 
-# ifeq (bcc32,${CC_ID})
-# # NOTE: *untested* configuration
-# CXX := ${CC_ID}
-# LD := ilink32
-# CFLAGS := -I. -O2 -w-pro -TWC -P-c -v- -d -f- -ff- -vi
-# CFLAGS_COMPILE_ONLY := -c
-# LDFLAGS := -Tpe -v- -ap -c -x -V4.0 -GF:AGGRESSIVE
-# LIBDIR := $(MAKEDIR)\..\lib
-# LIBS := ${LIBDIR}\import32.lib ${LIBDIR}\cw32.lib
-# endif ## `bcc32` (Borland)
+ifeq (,$(filter-out bcc32,${CC_ID}))
+# NOTE: initial *untested* configuration; ToDO: attempt improved configuration/use of BCC55
+CXX := ${CC}
+LD := ${CC}
+INC_path := $(abspath $(shell where ${CC} 2>NUL))/../../include## `where` can be used as `bcc32` only exists on Windows hosts
+LIB_path := $(abspath $(shell where ${CC} 2>NUL))/../../lib## `where` can be used as `bcc32` only exists on Windows hosts
+## -q :: suppress banner logo
+CFLAGS := -q -I. -I"${INC_path}" -L"${LIB_path}" -O2 -w-pro -TWC -v- -d -f- -ff- -vi
+CXXFLAGS := -P
+CFLAGS_COMPILE_ONLY := -q -c
+CFLAGS_v :=
+# LDFLAGS := -q -Tpe -v- -ap -c -x -V4.0 -GF:AGGRESSIVE -L"${LIB_path}"
+LDFLAGS := -q
+
+CC_${CC_ID}_e := -e
+CC_${CC_ID}_o := -o
+LD_${CC_ID}_o := -e
+
+O_${CC_ID} := obj
+
+LIBS := ${LIB_path}\import32.lib ${LIB_path}\cw32.lib
+endif ## `bcc32` (Borland)
 
 DEFINETYPE := wn
 OBJ_deps := defines.h less.h funcs.h cmd.h
@@ -303,6 +321,18 @@ $(call %debug_var,CPPFLAGS)
 $(call %debug_var,CXXFLAGS)
 $(call %debug_var,LDFLAGS)
 
+CC_e := $(or ${CC_${CC_ID}_e},-o${SPACE})
+CC_o := $(or ${CC_${CC_ID}_o},-o${SPACE})
+LD_o := $(or ${LD_${CC_ID}_o},-o${SPACE})
+
+$(call %debug_var,CC_e)
+$(call %debug_var,CC_o)
+$(call %debug_var,LD_o)
+
+O := $(or ${O_${CC_ID}},o)
+
+$(call %debug_var,O)
+
 $(call %debug_var,COLOR)
 $(call %debug_var,DEBUG)
 $(call %debug_var,STATIC)
@@ -360,11 +390,7 @@ OS_PREFIX=
 ifeq (${OSID},win)
 OSID_name  := windows
 OS_PREFIX  := win.
-CC_e       := $(or $(if $(filter cl,${CC_ID}),/Fe),-o${SPACE})
-CC_o       := $(or $(if $(filter cl,${CC_ID}),/Fo),-o${SPACE})
-LD_o       := $(or $(if $(filter cl,${CC_ID}),/out:),-o${SPACE})
 EXEEXT     := .exe
-O          := $(if $(filter cl,${CC_ID}),obj,o)
 #
 AWK        := gawk ## from `scoop install gawk`; or "goawk" from `go get github.com/benhoyt/goawk`
 CAT        := "${SystemRoot}\System32\findstr" /r .*
@@ -379,16 +405,13 @@ FIND       := "${SystemRoot}\System32\find"
 FINDSTR    := "${SystemRoot}\System32\findstr"
 MORE       := "${SystemRoot}\System32\more"
 SORT       := "${SystemRoot}\System32\sort"
+WHICH      := where
 #
 ECHO_newline := echo.
 else
 OSID_name  ?= $(shell uname | tr '[:upper:]' '[:lower:]')
 OS_PREFIX  := ${OSID_name}.
-CC_e       := -o${SPACE}
-CC_o       := -o${SPACE}
-LD_o       := -o${SPACE}
 EXEEXT     := $()
-O          := o
 #
 AWK        := awk
 CAT        := cat
@@ -400,6 +423,7 @@ RM         := rm
 RM_r       := ${RM} -r
 RMDIR      := ${RM} -r
 SORT       := sort
+WHICH      := which
 #
 ECHO_newline := echo
 endif
@@ -459,7 +483,7 @@ CC_machine_raw := $(shell ${CC} ${CFLAGS_machine} 2>&1 | ${GREP} -n ".*" | ${GRE
 endif
 CC_machine_raw := $(subst ${ESC}1:,$(),${ESC}${CC_machine_raw})
 CC_ARCH := $(or $(filter $(subst -, ,${CC_machine_raw}),${ARCH_x86} ${ARCH_x86_64}),${ARCH_default})
-CC_machine := $(or $(and $(call %eq,cl,${CC}),${CC_ARCH}),${CC_machine_raw})
+CC_machine := $(or $(and $(filter cl bcc32,${CC_ID}),${CC_ARCH}),${CC_machine_raw})
 CC_ARCH_ID := $(if $(filter ${CC_ARCH},32 x32 ${ARCH_x86}),32,64)
 override ARCH := $(or ${ARCH},${CC_ARCH})
 ARCH_ID := $(if $(filter ${ARCH},32 x32 ${ARCH_x86}),32,64)
@@ -700,19 +724,19 @@ veryclean: realclean
 # ref: [make ~ `eval()`](http://make.mad-scientist.net/the-eval-function) @ <https://archive.is/rpUfG>
 
 ${PROJECT_TARGET}: ${OBJ_files} ${makefile_abs_path} | ${OUT_bin}
-	${LD} ${LDFLAGS} $(addprefix ",$(addsuffix ",${OBJ_files})) ${LIBS} ${LD_o}"$@"
+	${LD} ${LDFLAGS} ${LD_o}"$@" $(addprefix ",$(addsuffix ",${OBJ_files})) ${LIBS}
 	$(if $(and ${STRIP},$(call %is_falsey,${DEBUG})),${STRIP} "$@",)
 	@${ECHO} $(call %shell_quote,$(call %success_text,made '$@'.))
 
 ${OUT_obj}/%.${O}: ${SRC_DIR}/%.c ${makefile_abs_path} | ${OUT_obj}
-	${CC} ${CFLAGS_COMPILE_ONLY} ${CPPFLAGS} ${CFLAGS} "$<" ${CC_o}"$@"
+	${CC} ${CFLAGS_COMPILE_ONLY} ${CPPFLAGS} ${CFLAGS} ${CC_o}"$@" "$<"
 
 ${OUT_obj}/%.${O}: ${SRC_DIR}/%.cpp ${makefile_abs_path} | ${OUT_obj}
-	${CXX} ${CFLAGS_COMPILE_ONLY} ${CPPFLAGS} ${CXXFLAGS} ${CFLAGS} "$<" ${CC_o}"$@"
+	${CXX} ${CFLAGS_COMPILE_ONLY} ${CPPFLAGS} ${CXXFLAGS} ${CC_o}"$@" ${CFLAGS} "$<"
 
 ${OUT_obj}/%.${O}: ${SRC_DIR}/%.cxx ${makefile_abs_path} | ${OUT_obj}
-	${CXX} ${CFLAGS_COMPILE_ONLY} ${CPPFLAGS} ${CXXFLAGS} ${CFLAGS} "$<" ${CC_o}"$@"
-#or ${CC} ${CFLAGS_COMPILE_ONLY} ${CPPFLAGS} ${CFLAGS} "$<" ${CC_o}"$@"
+	${CXX} ${CFLAGS_COMPILE_ONLY} ${CPPFLAGS} ${CXXFLAGS} ${CC_o}"$@" ${CFLAGS} "$<"
+#or ${CC} ${CFLAGS_COMPILE_ONLY} ${CPPFLAGS} ${CFLAGS} ${CC_o}"$@" "$<"
 
 ####
 

--- a/Makefile.win
+++ b/Makefile.win
@@ -343,17 +343,17 @@ $(call %debug_var,MAKEFLAGS_debug)
 ####
 
 # require at least `make` v4.0 (minimum needed for correct path functions)
-MAKE_VERSION_major := $(word 1,$(subst ., ,$(MAKE_VERSION)))
-MAKE_VERSION_minor := $(word 2,$(subst ., ,$(MAKE_VERSION)))
-MAKE_VERSION_fail := $(filter $(MAKE_VERSION_major),3 2 1 0)
+MAKE_VERSION_major := $(word 1,$(subst ., ,${MAKE_VERSION}))
+MAKE_VERSION_minor := $(word 2,$(subst ., ,${MAKE_VERSION}))
+MAKE_VERSION_fail := $(filter ${MAKE_VERSION_major},3 2 1 0)
 ifeq (${MAKE_VERSION_major},4)
-MAKE_VERSION_fail := $(filter $(MAKE_VERSION_minor),)
+MAKE_VERSION_fail := $(filter ${MAKE_VERSION_minor},)
 endif
 $(call %debug_var,MAKE_VERSION)
 $(call %debug_var,MAKE_VERSION_major)
 $(call %debug_var,MAKE_VERSION_minor)
 $(call %debug_var,MAKE_VERSION_fail)
-ifneq ($(MAKE_VERSION_fail),)
+ifneq (${MAKE_VERSION_fail},)
 $(call %error,`make` v4.0+ required (currently using v${MAKE_VERSION}))
 endif
 
@@ -380,7 +380,7 @@ $(call %error,<SPACE>'s within project directory may cause issues)
 endif
 
 # Since we rely on paths relative to the makefile location, abort if make isn't being run from there.
-ifneq ($(makefile_dir),$(current_dir))
+ifneq (${makefile_dir},${current_dir})
 $(call %error,Invalid current directory; this makefile must be invoked from the directory it resides in)
 endif
 

--- a/Makefile.win
+++ b/Makefile.win
@@ -73,6 +73,8 @@ CFLAGS_ARCH_32 := -m32
 CFLAGS_ARCH_64 := -m64
 CFLAGS_DEBUG_true := -DDEBUG -O0 -g
 CFLAGS_DEBUG_false := -DNDEBUG -O3
+# CFLAGS_STATIC_false := -shared
+# CFLAGS_STATIC_true := -static
 CFLAGS_VERBOSE_true := -v
 CFLAGS_check := -v
 CFLAGS_machine := -dumpmachine
@@ -91,6 +93,8 @@ LDFLAGS := $()
 LDFLAGS_ARCH_32 := -m32
 LDFLAGS_ARCH_64 := -m64
 LDFLAGS_DEBUG_false := -Xlinker --strip-all
+# LDFLAGS_STATIC_false := -pie
+# LDFLAGS_STATIC_false := -shared
 # LDFLAGS_STATIC_true := -static -static-libgcc -static-libstdc++
 LDFLAGS_STATIC_true := -static
 LDFLAGS_clang_nix := -lstdc++
@@ -547,6 +551,7 @@ $(call %debug_var,OUT_DIR_EXT)
 CFLAGS += ${CFLAGS_ARCH_${ARCH_ID}}
 CFLAGS += ${CFLAGS_TARGET}
 CFLAGS += ${CFLAGS_DEBUG_${DEBUG}}
+CFLAGS += ${CFLAGS_STATIC_${STATIC}}
 CFLAGS += ${CFLAGS_DEBUG_${DEBUG}_STATIC_${STATIC}}
 CFLAGS += ${CFLAGS_VERBOSE_${VERBOSE}}
 

--- a/Makefile.win
+++ b/Makefile.win
@@ -50,8 +50,8 @@ CC_ID := $(lastword $(subst -,$() $(),${CC}))
 
 ifeq (,$(filter-out clang gcc,${CC_ID}))
 ## `clang` or `gcc`
-CXX = ${CC:gcc=g}++
-LD = ${CXX}
+CXX := ${CC:gcc=g}++
+LD := ${CXX}
 STRIP_CC_clang_OSID_nix := strip
 STRIP_CC_clang_OSID_win := llvm-strip
 STRIP_CC_gcc := strip
@@ -107,9 +107,9 @@ LIBS := $()
 endif ## `clang` or `gcc`
 
 ifeq (cl,${CC_ID})
-CXX = cl
-LD = link
-STRIP = $()
+CXX := cl
+LD := link
+STRIP := $()
 ## `cl` (MSVC)
 ## ref: <https://docs.microsoft.com/en-us/cpp/build/reference/compiler-options-listed-by-category> @@ <https://archive.is/PTPDN>
 ## /nologo :: startup without logo display
@@ -159,24 +159,24 @@ endif ## `cl` (MSVC)
 
 # ifeq (bcc32,${CC_ID})
 # # NOTE: *untested* configuration
-# CXX = ${CC_ID}
-# LD = ilink32
+# CXX := ${CC_ID}
+# LD := ilink32
 # CFLAGS := -I. -O2 -w-pro -TWC -P-c -v- -d -f- -ff- -vi
 # CFLAGS_COMPILE_ONLY := -c
 # LDFLAGS := -Tpe -v- -ap -c -x -V4.0 -GF:AGGRESSIVE
-# LIBDIR = $(MAKEDIR)\..\lib
-# LIBS = ${LIBDIR}\import32.lib ${LIBDIR}\cw32.lib
+# LIBDIR := $(MAKEDIR)\..\lib
+# LIBS := ${LIBDIR}\import32.lib ${LIBDIR}\cw32.lib
 # endif ## `bcc32` (Borland)
 
 DEFINETYPE := wn
 OBJ_deps := defines.h less.h funcs.h cmd.h
 
 # `make` command line flags/options
-COLOR ?= $(if $(or ${MAKE_TERMOUT},${MAKE_TERMERR}),true,false)## enable colorized output ('truthy'-type)
-DEBUG ?= false## enable compiler debug flags/options ('truthy'-type; default == false)
-STATIC ?= true## compile to statically linked executable ('truthy'-type; default == true)
-VERBOSE ?= false## verbose `make` output ('truthy'-type; default == false)
-MAKEFLAGS_debug ?= $(if $(findstring d,${MAKEFLAGS}),true,false)## Makefile debug output ('truthy'-type; default == false) ## NOTE: use `-d` or `MAKEFLAGS_debug=1`, `--debug[=FLAGS]` does not set MAKEFLAGS correctly (see <https://savannah.gnu.org/bugs/?func=detailitem&item_id=58341>)
+COLOR := $(if $(or ${MAKE_TERMOUT},${MAKE_TERMERR}),true,false)## enable colorized output ('truthy'-type)
+DEBUG := false## enable compiler debug flags/options ('truthy'-type; default == false)
+STATIC := true## compile to statically linked executable ('truthy'-type; default == true)
+VERBOSE := false## verbose `make` output ('truthy'-type; default == false)
+MAKEFLAGS_debug := $(if $(findstring d,${MAKEFLAGS}),true,false)## Makefile debug output ('truthy'-type; default == false) ## NOTE: use `-d` or `MAKEFLAGS_debug=1`, `--debug[=FLAGS]` does not set MAKEFLAGS correctly (see <https://savannah.gnu.org/bugs/?func=detailitem&item_id=58341>)
 
 #### End of system configuration section. ####
 
@@ -184,13 +184,26 @@ falsey := false 0 f n no off
 false := $()
 true := true
 truthy := ${true}
+
+devnull := $(if $(filter win,${OSID}),NUL,/dev/null)
+int_max := 2147483647## largest signed 32-bit integer; used as arbitrary max expected list length
+
+NULL := $()
+BACKSLASH := $()\$()
+COMMA := ,
+DOT := .
 ESC := $()$()## literal ANSI escape character (required for ANSI color display output; also used for some string matching)
-int_max := 2147483647## largest signed 32-bit integer; arbitrary max expected list length
+HASH := \#
+PAREN_OPEN := $()($()
+PAREN_CLOSE := $())$()
+SLASH := /
+SPACE := $() $()
+
 [lower] := a b c d e f g h i j k l m n o p q r s t u v w x y z
 [upper] := A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
 [alpha] := ${[lower]} ${[upper]}
 [digit] := 1 2 3 4 5 6 7 8 9 0
-[punct] = ~ ` ! @ ${HASH} ${DOLLAR} % ^ & * ${OPEN_PAREN} ${CLOSE_PAREN} _ - + = { } [ ] | ${BACKSLASH} : ; " ' < > ${COMMA} ? ${SLASH} .
+[punct] := ~ ` ! @ ${HASH} ${DOLLAR} % ^ & * ${PAREN_OPEN} ${PAREN_CLOSE} _ - + = { } [ ] | ${BACKSLASH} : ; " ' < > ${COMMA} ? ${SLASH} ${DOT}
 
 %not = $(if ${1},${false},${true})
 %eq = $(and $(findstring $(1),$(2)),$(findstring $(2),$(1)))
@@ -312,21 +325,6 @@ $(call %debug_var,LIB)
 
 ####
 
-devnull := $(if $(filter win,${OSID}),NUL,/dev/null)
-, := ,
-COMMA := ,
-DOT := .
-HASH := \#
-BQUOTE := `
-DQUOTE := "
-SQUOTE := '
-SLASH := /
-OPEN_PAREN := $()($()
-CLOSE_PAREN := $())$()
-BACKSLASH := $()\$()
-NULL := $()
-SPACE := $() $()
-
 # detect ${CC}
 CC_check_flags := $(if $(filter cl,${CC_ID}),,-v)
 ifeq (,$(shell "${CC}" ${CC_check_flags} >${devnull} 2>&1 && echo ${CC} present))
@@ -346,7 +344,7 @@ endif
 
 OS_PREFIX=
 ifeq (${OSID},win)
-OSID_name  ?= windows
+OSID_name  := windows
 OS_PREFIX  := win.
 CC_e       := $(or $(if $(filter cl,${CC_ID}),/Fe),-o${SPACE})
 CC_o       := $(or $(if $(filter cl,${CC_ID}),/Fo),-o${SPACE})
@@ -368,9 +366,7 @@ FINDSTR    := "${SystemRoot}\System32\findstr"
 MORE       := "${SystemRoot}\System32\more"
 SORT       := "${SystemRoot}\System32\sort"
 #
-ECHO_NL    := echo:
-ECHO_DQ    := $()
-ECHO_SQ    := $()
+ECHO_newline := echo.
 else
 OSID_name  ?= $(shell uname | tr '[:upper:]' '[:lower:]')
 OS_PREFIX  := ${OSID_name}.
@@ -391,9 +387,7 @@ RM_r       := ${RM} -r
 RMDIR      := ${RM} -r
 SORT       := sort
 #
-ECHO_NL    := echo
-ECHO_DQ    := "
-ECHO_SQ    := '
+ECHO_newline := echo
 endif
 
 # calculate `strip` for ${CC_ID} and ${OSID}
@@ -580,8 +574,8 @@ endif
 
 ####
 
-BUILD_DIR ?= ${HASH}build
-CONFIG    ?= $(if $(call %is_truthy,${DEBUG}),debug,release)
+BUILD_DIR := ${HASH}build
+CONFIG    := $(if $(call %is_truthy,${DEBUG}),debug,release)
 
 SRC_DIR := .
 OUT_DIR := .

--- a/Makefile.win
+++ b/Makefile.win
@@ -28,6 +28,18 @@ NAME := less ## empty/null => autoset to name of containing folder
 # spell-checker:ignore (utils) goawk ilink
 # spell-checker:ignore (vars) BQUOTE CFLAGS CPPFLAGS CXXFLAGS DEFINETYPE DQUOTE EXEEXT LDFLAGS LIBDIR LIBPATH MAKEDIR OBJ_deps OSID PAREN SQUOTE devnull falsey fileset punct truthy
 
+####
+
+OSID := $(or $(and $(filter .exe,$(patsubst %.exe,.exe,$(subst $() $(),_,${SHELL}))),$(filter win,${OS:Windows_NT=win})),nix)## OSID == [nix,win]
+# for Windows OS, set SHELL to `%ComSpec%` or `cmd` (note: environment/${OS}=="Windows_NT" for XP, 2000, Vista, 7, 10 ...)
+# * `make` may otherwise use an incorrect shell (eg, `bash`), if found; "syntax error: unexpected end of file" error output is indicative
+ifeq (${OSID},win)
+# use case and location fallbacks; note: assumes *no spaces* within ${ComSpec}, ${SystemRoot}, or ${windir}
+COMSPEC := $(or ${ComSpec},${COMSPEC},${comspec})
+SystemRoot := $(or ${SystemRoot},${SYSTEMROOT},${systemroot},${windir})
+SHELL := $(firstword $(wildcard ${COMSPEC} ${SystemRoot}/System32/cmd.exe) cmd)
+endif
+
 #### Start of system configuration section. ####
 
 # * default to `clang`

--- a/Makefile.win
+++ b/Makefile.win
@@ -448,7 +448,7 @@ endif
 
 ARCH_default := i686
 ARCH_x86 := i386 i586 i686 x86
-ARCH_x86_64 := x64 x86_64
+ARCH_x86_64 := amd64 x64 x86_64 x86_amd64
 ARCH_allowed := $(sort 32 x32 ${ARCH_x86} 64 ${ARCH_x86_64})
 ifneq (${ARCH},$(filter ${ARCH},${ARCH_allowed}))
 $(call %error,Unknown architecture "$(ARCH)"; valid values are [""$(subst $(SPACE),$(),$(addprefix ${COMMA}",$(addsuffix ",${ARCH_allowed})))])

--- a/Makefile.win
+++ b/Makefile.win
@@ -1,13 +1,13 @@
 # Makefile for `less`
-# Windows version; MS Visual C/C++
-# make (GNU make) version
-
+# Cross-platform (bash/sh + CMD/PowerShell)
+# `cl`, `clang`, and `gcc` (defaults to `CC=clang`)
+# GNU make (gmake) compatible; ref: <https://www.gnu.org/software/make/manual>
 # Copyright (C) 2020 ~ Roy Ivy III <rivy.dev@gmail.com>; MIT+Apache-2.0 license
 
 # NOTE: * requires `make` version 4.0+ (minimum needed for correct path functions)
 # NOTE: `make` doesn't handle spaces within file names without gyrations (see <https://stackoverflow.com/questions/9838384/can-gnu-make-handle-filenames-with-spaces>@@<https://archive.is/PYKKq>)
 
-# `make -f Makefile.win.msvc`
+# `make -f Makefile.win`
 
 NAME := less ## empty/null => autoset to name of containing folder
 
@@ -695,5 +695,7 @@ ${OUT_obj}/%.${O}: ${SRC_DIR}/%.cpp ${makefile_abs_path} | ${OUT_obj}
 ${OUT_obj}/%.${O}: ${SRC_DIR}/%.cxx ${makefile_abs_path} | ${OUT_obj}
 	${CXX} ${CFLAGS_COMPILE_ONLY} ${CPPFLAGS} ${CXXFLAGS} ${CFLAGS} "$<" ${CC_o}"$@"
 #or ${CC} ${CFLAGS_COMPILE_ONLY} ${CPPFLAGS} ${CFLAGS} "$<" ${CC_o}"$@"
+
+####
 
 $(foreach dir,${out_dirs_for_rules},$(eval $(call @mkdir_rule,${dir})))

--- a/Makefile.win
+++ b/Makefile.win
@@ -205,9 +205,9 @@ SPACE := $() $()
 [digit] := 1 2 3 4 5 6 7 8 9 0
 [punct] := ~ ` ! @ ${HASH} ${DOLLAR} % ^ & * ${PAREN_OPEN} ${PAREN_CLOSE} _ - + = { } [ ] | ${BACKSLASH} : ; " ' < > ${COMMA} ? ${SLASH} ${DOT}
 
-%not = $(if ${1},${false},${true})
-%eq = $(and $(findstring $(1),$(2)),$(findstring $(2),$(1)))
-%neq = $(call %not,$(call %eq,${1},${2}))
+%not = $(if ${1},${false},$(or ${1},${true}))
+%eq = $(or $(and $(findstring ${1},${2}),$(findstring ${2},${1})),$(if ${1}${2},${false},${true}))# note: `call %eq,$(),$()` => ${true}
+%neq = $(if $(call %eq,${1},${2}),${false},$(or ${1},${2},${true}))# note: ${1} != ${2} => ${false}; ${1} == ${2} => first non-empty value (or ${true})
 
 %falsey = $(firstword ${falsey})
 %truthy = $(firstword ${truthy})
@@ -238,9 +238,15 @@ ifeq (${OSID},win)
 %rm_file = if EXIST "${1}" ${RM} "${1}" && echo $(call %info_text,"${1}" removed)
 %rm_fileset = $(if $(shell for %%G in (${1}) do ${RM} "%%G" >${devnull} && echo done),$(shell echo echo $(call %info_text,"${1}" removed)),)
 else
-%rm_dir = ls -d "${1}" >${devnull} 2>&1 && { ${RMDIR} "${1}" && echo ${ECHO_SQ}$(call %info_text,"${1}" removed)${ECHO_SQ}; } || true
-%rm_file = ls -d "${1}" >${devnull} 2>&1 && { ${RM} "${1}" && echo ${ECHO_SQ}$(call %info_text,"${1}" removed)${ECHO_SQ}; } || true
-%rm_fileset = for file in ${1}; do ls -d "${1}" >${devnull} 2>&1 && ${RM} "$${file}"; done && echo ${ECHO_SQ}$(call %info_text,"${1}" removed)${ECHO_SQ} || true
+%rm_dir = ls -d "${1}" >${devnull} 2>&1 && { ${RMDIR} "${1}" && echo $(call %shell_quote,$(call %info_text,"${1}" removed)); } || true
+%rm_file = ls -d "${1}" >${devnull} 2>&1 && { ${RM} "${1}" && echo $(call %shell_quote,$(call %info_text,"${1}" removed)); } || true
+%rm_fileset = for file in ${1}; do ls -d "${1}" >${devnull} 2>&1 && ${RM} "$${file}"; done && echo $(call %shell_quote,$(call %info_text,"${1}" removed)) || true
+endif
+
+ifeq (${OSID},win)
+%shell_quote = $(call %tr,^ | < > %,^^ ^| ^< ^> ^%,${1})
+else
+%shell_quote = '$(call %tr,','"'"',${1})'
 endif
 
 @mkdir_rule = ${1} : ${2} ; ${MKDIR} "$$@"
@@ -630,27 +636,28 @@ $(call %debug_var,OBJ_files)
 ${AUX_targets}: %${EXEEXT}: %.${O} version.${O} ${makefile_abs_path} | ${OUT_bin}
 	${LD} ${LDFLAGS} "$<" "version.${O}" ${LIBS} ${LD_o}"$@"
 	$(if $(and ${STRIP},$(call %is_falsey,${DEBUG})),${STRIP} "$@",)
-	@${ECHO} ${ECHO_DQ}$(call %success_text,made '$@'.)${ECHO_DQ}
+	@${ECHO} $(call %shell_quote,$(call %success_text,made '$@'.))
 
 ${OBJ_files}: ${OBJ_deps} | ${OUT_obj}
 
 defines.h: defines.${DEFINETYPE}
-	${CP} defines.${DEFINETYPE} defines.h
+	@${CP} defines.${DEFINETYPE} defines.h >${devnull}
+	@${ECHO} $(call %shell_quote,$(call %info_text,created '$@' from '$<'.))
 
 ####
 
 .PHONY: help
 help: ## Display help
-	@${ECHO} ${BQUOTE}${make_invoke_alias}${BQUOTE}
-	@${ECHO} Usage: ${BQUOTE}${make_invoke_alias} [ARCH=..] [COLOR=..] [DEBUG=..] [STATIC=..] [TARGET=..] [VERBOSE=..] [MAKE_TARGET...]${BQUOTE}
-	@${ECHO} Builds ${SQUOTE}${PROJECT_TARGET}${SQUOTE} within ${DQUOTE}$(current_dir)${DQUOTE}
-	@${ECHO_NL}
-	@${ECHO} MAKE_TARGETs:
-	@${ECHO_NL}
+	@${ECHO} $(call %shell_quote,`${make_invoke_alias}`)
+	@${ECHO} $(call %shell_quote,Usage: `${make_invoke_alias} [ARCH=..] [COLOR=..] [DEBUG=..] [STATIC=..] [TARGET=..] [VERBOSE=..] [MAKE_TARGET...]`)
+	@${ECHO} $(call %shell_quote,Builds '${PROJECT_TARGET}' within "$(current_dir)")
+	@${ECHO_newline}
+	@${ECHO} $(call %shell_quote,MAKE_TARGETs:)
+	@${ECHO_newline}
 ifeq (${OSID},win)
 	@${FINDSTR} "^[a-zA-Z-]*:.*${HASH}${HASH}" "${makefile_path}" | ${SORT} | for /f "tokens=1-2,* delims=:${HASH}" %%g in ('${MORE}') do @(@call set "t=%%g                " & @call echo ${color_success}%%t:~0,15%%${color_reset} ${color_info}%%i${color_reset})
 else
-	@${GREP} -P "(?i)^[[:alpha:]-]+:" "${makefile_path}" | ${SORT} | ${AWK} 'match($$0,"^([[:alpha:]]+):.*?${HASH}${HASH}\\s*(.*)$$",m){ printf "${color_success}%-10s${color_reset}\t${color_info}%s${color_reset}\n", m[1], m[2] }'
+	@${GREP} -P "(?i)^[[:alpha:]-]+:" "${makefile_path}" | ${SORT} | ${AWK} 'match($$0,"^([[:alpha:]]+):.*?${HASH}${HASH}\\s*(.*)$$",m){ printf "${color_success}%-10s${color_reset}\t${color_info}%s${color_reset}\n", m[1], m[2] }END{printf "\n"}'
 endif
 
 .PHONY: run
@@ -686,7 +693,7 @@ veryclean: realclean
 ${PROJECT_TARGET}: ${OBJ_files} ${makefile_abs_path} | ${OUT_bin}
 	${LD} ${LDFLAGS} $(addprefix ",$(addsuffix ",${OBJ_files})) ${LIBS} ${LD_o}"$@"
 	$(if $(and ${STRIP},$(call %is_falsey,${DEBUG})),${STRIP} "$@",)
-	@${ECHO} ${ECHO_DQ}$(call %success_text,made '$@'.)${ECHO_DQ}
+	@${ECHO} $(call %shell_quote,$(call %success_text,made '$@'.))
 
 ${OUT_obj}/%.${O}: ${SRC_DIR}/%.c ${makefile_abs_path} | ${OUT_obj}
 	${CC} ${CFLAGS_COMPILE_ONLY} ${CPPFLAGS} ${CFLAGS} "$<" ${CC_o}"$@"

--- a/Makefile.win
+++ b/Makefile.win
@@ -288,6 +288,14 @@ override MAKEFLAGS_debug := $(call %as_truthy,$(or $(call %is_truthy,${MAKEFLAGS
 $(call %debug_var,OSID)
 $(call %debug_var,SHELL)
 
+$(call %debug_var,CC)
+$(call %debug_var,CXX)
+$(call %debug_var,LD)
+$(call %debug_var,CFLAGS)
+$(call %debug_var,CPPFLAGS)
+$(call %debug_var,CXXFLAGS)
+$(call %debug_var,LDFLAGS)
+
 $(call %debug_var,COLOR)
 $(call %debug_var,DEBUG)
 $(call %debug_var,STATIC)

--- a/Makefile.win
+++ b/Makefile.win
@@ -42,8 +42,9 @@ endif
 
 #### Start of system configuration section. ####
 
-# * default to `clang`
-CC = clang
+# * default to `clang` (fallback to `gcc`; via a portable shell test)
+CC := $(and $(filter-out default,$(origin CC)),${CC})## use any non-make defined value as default ## note: used to avoid requiring a recursive definition of ${CC} with I/O in the later default determination
+CC := $(or ${CC},$(subst -FOUND,,$(filter clang-FOUND,$(shell clang --version 2>&1 && echo clang-FOUND))),gcc)
 
 CC_ID := $(lastword $(subst -,$() $(),${CC}))
 

--- a/Makefile.win
+++ b/Makefile.win
@@ -572,6 +572,8 @@ CFLAGS += ${CFLAGS_DEBUG_${DEBUG}}
 CFLAGS += ${CFLAGS_DEBUG_${DEBUG}_STATIC_${STATIC}}
 CFLAGS += ${CFLAGS_VERBOSE_${VERBOSE}}
 
+CPPFLAGS += -D_CC="${CC}" -D_CC_ID="${CC_ID}" -D_CC_version="${CC_version}" -D_CC_machine="${CC_machine}" -D_ARCH="${ARCH_ID}"
+
 CXXFLAGS += ${CXXFLAGS_${CC_ID}}
 
 LDFLAGS += ${LDFLAGS_ARCH_${ARCH_ID}}
@@ -582,10 +584,12 @@ LDFLAGS += ${LDFLAGS_${CC_ID}}
 LDFLAGS += ${LDFLAGS_${CC_ID}_${OSID}}
 
 CFLAGS := $(strip ${CFLAGS})
+CPPFLAGS := $(strip ${CPPFLAGS})
 CXXFLAGS := $(strip ${CXXFLAGS})
 LDFLAGS := $(strip ${LDFLAGS})
 
 $(call %debug_var,CFLAGS)
+$(call %debug_var,CPPFLAGS)
 $(call %debug_var,CXXFLAGS)
 $(call %debug_var,LDFLAGS)
 

--- a/Makefile.win
+++ b/Makefile.win
@@ -191,6 +191,7 @@ DEFINETYPE := wn
 OBJ_deps := defines.h less.h funcs.h cmd.h
 
 # `make` command line flags/options
+CC_DEFINES := false## provide `CC_...` defines to compiler ('truthy'-type)
 COLOR := $(if $(or ${MAKE_TERMOUT},${MAKE_TERMERR}),true,false)## enable colorized output ('truthy'-type)
 DEBUG := false## enable compiler debug flags/options ('truthy'-type; default == false)
 STATIC := true## compile to statically linked executable ('truthy'-type; default == true)
@@ -572,7 +573,7 @@ CFLAGS += ${CFLAGS_DEBUG_${DEBUG}}
 CFLAGS += ${CFLAGS_DEBUG_${DEBUG}_STATIC_${STATIC}}
 CFLAGS += ${CFLAGS_VERBOSE_${VERBOSE}}
 
-CPPFLAGS += -D_CC="${CC}" -D_CC_ID="${CC_ID}" -D_CC_version="${CC_version}" -D_CC_machine="${CC_machine}" -D_ARCH="${ARCH_ID}"
+CPPFLAGS += $(if $(call %is_truthy,${CC_DEFINES}),-D_CC="${CC}" -D_CC_ID="${CC_ID}" -D_CC_version="${CC_version}" -D_CC_machine="${CC_machine}" -D_CC_target="${TARGET}" -D_CC_target_arch="${ARCH_ID}",$())
 
 CXXFLAGS += ${CXXFLAGS_${CC_ID}}
 
@@ -686,7 +687,7 @@ defines.h: defines.${DEFINETYPE}
 .PHONY: help
 help: ## Display help
 	@${ECHO} $(call %shell_quote,`${make_invoke_alias}`)
-	@${ECHO} $(call %shell_quote,Usage: `${make_invoke_alias} [ARCH=..] [COLOR=..] [DEBUG=..] [STATIC=..] [TARGET=..] [VERBOSE=..] [MAKE_TARGET...]`)
+	@${ECHO} $(call %shell_quote,Usage: `${make_invoke_alias} [ARCH=..] [CC_DEFINES=..] [COLOR=..] [DEBUG=..] [STATIC=..] [TARGET=..] [VERBOSE=..] [MAKE_TARGET...]`)
 	@${ECHO} $(call %shell_quote,Builds '${PROJECT_TARGET}' within "$(current_dir)")
 	@${ECHO_newline}
 	@${ECHO} $(call %shell_quote,MAKE_TARGETs:)

--- a/Makefile.win
+++ b/Makefile.win
@@ -16,7 +16,7 @@ NAME := less ## empty/null => autoset to name of containing folder
 # spell-checker:ignore () brac cmdbuf forwback funcs ifile lessecho lesskey linenum lsystem optfunc opttbl scrsize ttyin
 
 # spell-checker:ignore (targets) realclean vclean veryclean
-# spell-checker:ignore (make) CURDIR MAKEFLAGS SHELLSTATUS TERMERR TERMOUT abspath addprefix addsuffix endef eval findstring firstword gmake ifeq ifneq lastword notdir prepend undefine wordlist
+# spell-checker:ignore (make) CURDIR MAKEFLAGS SHELLSTATUS TERMERR TERMOUT abspath addprefix addsuffix endef eval findstring firstword gmake ifeq ifneq lastword notdir patsubst prepend undefine wordlist
 #
 # spell-checker:ignore (CC) DDEBUG DNDEBUG NDEBUG Ofast Werror Wextra Xclang Xlinker dumpmachine flto flto-visibility-public-std fpie nodefaultlib nologo nothrow
 # spell-checker:ignore (abbrev/acronyms) LLVM MSVC MinGW POSIX VCvars
@@ -26,7 +26,7 @@ NAME := less ## empty/null => autoset to name of containing folder
 # spell-checker:ignore (shell/nix) mkdir printf rmdir uname
 # spell-checker:ignore (shell/win) COMSPEC SystemDrive SystemRoot findstr findstring mkdir windir
 # spell-checker:ignore (utils) goawk ilink
-# spell-checker:ignore (vars) BQUOTE CFLAGS CPPFLAGS CXXFLAGS DEFINETYPE DQUOTE EXEEXT LDFLAGS LIBDIR LIBPATH MAKEDIR OBJ_deps OSID PAREN SQUOTE devnull falsey fileset punct truthy
+# spell-checker:ignore (vars) CFLAGS CPPFLAGS CXXFLAGS DEFINETYPE EXEEXT LDFLAGS LIBPATH MAKEDIR OBJ_deps OSID PAREN devnull falsey fileset punct truthy
 
 ####
 

--- a/Makefile.win
+++ b/Makefile.win
@@ -445,11 +445,11 @@ endif
 ####
 
 ARCH_default := i686
-ARCH_i686 := i686 x86
+ARCH_x86 := i386 i586 i686 x86
 ARCH_x86_64 := x64 x86_64
-ARCH_allowed := $(sort 32 x32 ${ARCH_i686} 64 ${ARCH_x86_64})
+ARCH_allowed := $(sort 32 x32 ${ARCH_x86} 64 ${ARCH_x86_64})
 ifneq (${ARCH},$(filter ${ARCH},${ARCH_allowed}))
-$(call %error,Unknown architecture "$(ARCH)"; valid values are [""$(subst $(SPACE),$(),$(addprefix ${COMMA}${DQUOTE},$(addsuffix ${DQUOTE},${ARCH_allowed})))])
+$(call %error,Unknown architecture "$(ARCH)"; valid values are [""$(subst $(SPACE),$(),$(addprefix ${COMMA}",$(addsuffix ",${ARCH_allowed})))])
 endif
 
 ifeq (${OSID},win)
@@ -458,11 +458,11 @@ else ## nix
 CC_machine_raw := $(shell ${CC} ${CFLAGS_machine} 2>&1 | ${GREP} -n ".*" | ${GREP} "^1:" )
 endif
 CC_machine_raw := $(subst ${ESC}1:,$(),${ESC}${CC_machine_raw})
-CC_ARCH := $(or $(filter $(subst -, ,${CC_machine_raw}),${ARCH_i686} ${ARCH_x86_64}),${ARCH_default})
+CC_ARCH := $(or $(filter $(subst -, ,${CC_machine_raw}),${ARCH_x86} ${ARCH_x86_64}),${ARCH_default})
 CC_machine := $(or $(and $(call %eq,cl,${CC}),${CC_ARCH}),${CC_machine_raw})
-CC_ARCH_ID := $(if $(filter ${CC_ARCH},32 x32 ${ARCH_i686}),32,64)
+CC_ARCH_ID := $(if $(filter ${CC_ARCH},32 x32 ${ARCH_x86}),32,64)
 override ARCH := $(or ${ARCH},${CC_ARCH})
-ARCH_ID := $(if $(filter ${ARCH},32 x32 ${ARCH_i686}),32,64)
+ARCH_ID := $(if $(filter ${ARCH},32 x32 ${ARCH_x86}),32,64)
 
 $(call %debug_var,CC_machine_raw)
 $(call %debug_var,CC_machine)

--- a/Makefile.win
+++ b/Makefile.win
@@ -404,11 +404,20 @@ SORT       := sort
 ECHO_newline := echo
 endif
 
-# calculate `strip` for ${CC_ID} and ${OSID}
-STRIP := $(or ${STRIP_CC_${CC_ID}_OSID_${OSID}}, ${STRIP_CC_${CC_ID}}, ${STRIP})
-$(call %debug_var,STRIP)
-# * and... ${STRIP} available? (missing in some distributions)
+# find/calculate best available `strip`
 STRIP_check_flags := --version
+# * calculate `strip`; general overrides for ${CC_ID} and ${OSID}
+STRIP := $(or ${STRIP_CC_${CC_ID}_OSID_${OSID}},${STRIP_CC_${CC_ID}},${STRIP})
+# $(call %debug_var,STRIP)
+# * available as ${CC}-prefixed variant?
+STRIP_CC_${CC}_name := $(call %neq,${CC:-${CC_ID}=-strip},${CC})
+$(call %debug_var,STRIP_CC_${CC}_name)
+STRIP_CC_${CC} := $(or ${STRIP_CC_${CC}},$(and ${STRIP_CC_${CC}_name},$(shell "${STRIP_CC_${CC}_name}" ${STRIP_check_flags} >${devnull} 2>&1 && echo ${STRIP_CC_${CC}_name})))
+$(call %debug_var,STRIP_CC_${CC})
+# * calculate `strip`; specific overrides for ${CC}
+STRIP := $(or ${STRIP_CC_${CC}},${STRIP})
+# $(call %debug_var,STRIP)
+# * and... ${STRIP} available? (missing in some distributions)
 STRIP := $(shell "${STRIP}" ${STRIP_check_flags} >${devnull} 2>&1 && echo ${STRIP})
 $(call %debug_var,STRIP)
 

--- a/Makefile.win
+++ b/Makefile.win
@@ -164,29 +164,6 @@ O_${CC_ID} := obj
 LIBS := user32.lib
 endif ## `cl` (MSVC)
 
-ifeq (,$(filter-out bcc32,${CC_ID}))
-# NOTE: initial *untested* configuration; ToDO: attempt improved configuration/use of BCC55
-CXX := ${CC}
-LD := ${CC}
-INC_path := $(abspath $(shell where ${CC} 2>NUL))/../../include## `where` can be used as `bcc32` only exists on Windows hosts
-LIB_path := $(abspath $(shell where ${CC} 2>NUL))/../../lib## `where` can be used as `bcc32` only exists on Windows hosts
-## -q :: suppress banner logo
-CFLAGS := -q -I. -I"${INC_path}" -L"${LIB_path}" -O2 -w-pro -TWC -v- -d -f- -ff- -vi
-CXXFLAGS := -P
-CFLAGS_COMPILE_ONLY := -q -c
-CFLAGS_v :=
-# LDFLAGS := -q -Tpe -v- -ap -c -x -V4.0 -GF:AGGRESSIVE -L"${LIB_path}"
-LDFLAGS := -q
-
-CC_${CC_ID}_e := -e
-CC_${CC_ID}_o := -o
-LD_${CC_ID}_o := -e
-
-O_${CC_ID} := obj
-
-LIBS := ${LIB_path}\import32.lib ${LIB_path}\cw32.lib
-endif ## `bcc32` (Borland)
-
 DEFINETYPE := wn
 OBJ_deps := defines.h less.h funcs.h cmd.h
 

--- a/Makefile.win.borland
+++ b/Makefile.win.borland
@@ -3,8 +3,10 @@
 # GNU make (gmake) compatible; ref: <https://www.gnu.org/software/make/manual>
 # Copyright (C) 2020 ~ Roy Ivy III <rivy.dev@gmail.com>; MIT+Apache-2.0 license
 
+# spell-checker:ignore () INCDIRS LIBDIRS bcc32 embcc32 embcc
+#
 # spell-checker:ignore (targets) distclean realclean vclean veryclean
-# spell-checker:ignore (make) abspath firstword ifeq ifndef ifneq lastword undefine vclean veryclean
+# spell-checker:ignore (make) abspath firstword gmake ifeq ifndef ifneq lastword undefine vclean veryclean
 #
 # spell-checker:ignore (acronyms/names) Borland Borland's LLVM MSVC MinGW POSIX VCvars
 # spell-checker:ignore (flags/options) DDEBUG DNDEBUG NDEBUG Werror Wextra Xclang defaultlib dumpmachine flto flto-visibility-public-std libcmt nologo nothrow
@@ -17,14 +19,17 @@
 #### Start of system configuration section. ####
 
 CC = bcc32
+LD := ilink32
+
 LIBDIR := $(subst /,\,$(abspath $(firstword $(shell scoop which ${CC} 2>NUL) $(shell where ${CC} 2>NUL))\..\..\lib))
-INCDIR := $(subst /,\,$(abspath ${LIBDIR}\..\include))
+INCDIRS := "$(subst /,\,$(abspath ${LIBDIR}\..\include))"
 LIBDIRS := "${LIBDIR}"
 
-CFLAGS = -q -O2 -w-pro -TWC -P-c -v- -d -f- -ff- -vi
-LDFLAGS = -q -Tpe -v- -ap -c -x -V4.0 -GF:AGGRESSIVE -L${LIBDIRS}
-LD = ilink32
-LIBS = import32.lib cw32.lib
+CFLAGS := -q -O2 -w-pro -TWC -P-c -v- -d -f- -ff- -vi
+LDFLAGS := -q -Tpe -v- -ap -c -x -V4.0 -GF:AGGRESSIVE -L${LIBDIRS}
+
+LD_INIT_OBJ := ${LIBDIR}\c0x32.obj
+LIBS := import32.lib cw32.lib
 
 #### End of system configuration section. ####
 
@@ -54,13 +59,13 @@ OBJ = \
 all: less lesskey lessecho
 
 less: ${OBJ}
-	${LD} ${LDFLAGS} ${LIBDIR}\c0x32.obj $^, $@,,${LIBS}
+	${LD} ${LDFLAGS} ${LD_INIT_OBJ} $^, $@,,${LIBS}
 
 lesskey: lesskey.obj version.obj
-	${LD} ${LDFLAGS} ${LIBDIR}\c0x32.obj $^, $@,,${LIBS}
+	${LD} ${LDFLAGS} ${LD_INIT_OBJ} $^, $@,,${LIBS}
 
 lessecho: lessecho.obj version.obj
-	${LD} ${LDFLAGS} ${LIBDIR}\c0x32.obj $^, $@,,${LIBS}
+	${LD} ${LDFLAGS} ${LD_INIT_OBJ} $^, $@,,${LIBS}
 
 defines.h: defines.wn
 	-@if EXIST "defines.h" del "defines.h" && echo "defines.h" removed

--- a/Makefile.win.borland
+++ b/Makefile.win.borland
@@ -1,6 +1,7 @@
-# Makefile for less.
-# Windows version
-# Borland C++ 5.5.1 free command line tools
+# Makefile for `less`
+# `bcc32` (Borland C++ 5.5.1 free command line tools); CMD/PowerShell host
+# GNU make (gmake) compatible; ref: <https://www.gnu.org/software/make/manual>
+# Copyright (C) 2020 ~ Roy Ivy III <rivy.dev@gmail.com>; MIT+Apache-2.0 license
 
 # spell-checker:ignore (targets) distclean realclean vclean veryclean
 # spell-checker:ignore (make) abspath firstword ifeq ifndef ifneq lastword undefine vclean veryclean
@@ -14,39 +15,33 @@
 # spell-checker:ignore () brac cmdbuf forwback funcs ifile lessecho lesskey linenum lsystem optfunc opttbl stdext ttyin
 
 #### Start of system configuration section. ####
-#
-# Borland's make knows its own location in the
-# filesystem.
-#
 
 CC = bcc32
-LIBDIR = $(MAKEDIR)\..\lib
+LIBDIR := $(subst /,\,$(abspath $(firstword $(shell scoop which ${CC} 2>NUL) $(shell where ${CC} 2>NUL))\..\..\lib))
+INCDIR := $(subst /,\,$(abspath ${LIBDIR}\..\include))
+LIBDIRS := "${LIBDIR}"
 
-CFLAGS = -O2 -w-pro -TWC -P-c -v- -d -f- -ff- -vi
-LDFLAGS = -Tpe -v- -ap -c -x -V4.0 -GF:AGGRESSIVE
+CFLAGS = -q -O2 -w-pro -TWC -P-c -v- -d -f- -ff- -vi
+LDFLAGS = -q -Tpe -v- -ap -c -x -V4.0 -GF:AGGRESSIVE -L${LIBDIRS}
 LD = ilink32
-LIBS = ${LIBDIR}\import32.lib ${LIBDIR}\cw32.lib
+LIBS = import32.lib cw32.lib
 
 #### End of system configuration section. ####
 
-# Set SHELL to `cmd` for Windows OS (note: environment/${OS}=="Windows_NT" for XP, 2000, Vista, 7, 10 ...)
-# * `make` may otherwise use an incorrect shell (eg, `bash`), if found; "syntax error: unexpected end of file" error output is indicative
-ifeq (${OS},Windows_NT)
-	# use case and location fallbacks; note: assumes *no spaces* within ${ComSpec}, ${SystemRoot}, or ${windir}
-	COMSPEC := $(or ${ComSpec},${COMSPEC},${comspec})
-	SystemRoot := $(or ${SystemRoot},${SYSTEMROOT},${systemroot},${windir})
-	SHELL := $(firstword $(wildcard ${COMSPEC} ${SystemRoot}/System32/cmd.exe) cmd)
-endif
-# $(info SHELL=${SHELL})
+# # Set SHELL to `cmd` for Windows OS (note: environment/${OS}=="Windows_NT" for XP, 2000, Vista, 7, 10 ...)
+# # * `make` may otherwise use an incorrect shell (eg, `bash`), if found; "syntax error: unexpected end of file" error output is indicative
+# ifeq (${OS},Windows_NT)
+# 	# use case and location fallbacks; note: assumes *no spaces* within ${ComSpec}, ${SystemRoot}, or ${windir}
+# 	COMSPEC := $(or ${ComSpec},${COMSPEC},${comspec})
+# 	SystemRoot := $(or ${SystemRoot},${SYSTEMROOT},${systemroot},${windir})
+# 	SHELL := $(firstword $(wildcard ${COMSPEC} ${SystemRoot}/System32/cmd.exe) cmd)
+# endif
+# # $(info SHELL=${SHELL})
 
 ####
 
-#
-# This rule allows us to supply the necessary -D options
-# in addition to whatever the user asks for.
-#
-.c.obj:
-	${CC} -c -I. ${CPPFLAGS} ${CFLAGS} $<
+%.obj: %.c
+	${CC} -c -I. -I${INCDIRS} ${CPPFLAGS} ${CFLAGS} $<
 
 OBJ = \
 	main.obj screen.obj brac.obj ch.obj charset.obj cmdbuf.obj \
@@ -58,33 +53,29 @@ OBJ = \
 
 all: less lesskey lessecho
 
-#
-# This is really horrible, but the command line is too long for
-# MS-DOS if we try to link ${OBJ}.
-#
 less: ${OBJ}
-	${LD} ${LDFLAGS} ${LIBDIR}\c0x32.obj $**, $@,,${LIBS}
+	${LD} ${LDFLAGS} ${LIBDIR}\c0x32.obj $^, $@,,${LIBS}
 
 lesskey: lesskey.obj version.obj
-	${LD} ${LDFLAGS} ${LIBDIR}\c0x32.obj $**, $@,,${LIBS}
+	${LD} ${LDFLAGS} ${LIBDIR}\c0x32.obj $^, $@,,${LIBS}
 
 lessecho: lessecho.obj version.obj
-	${LD} ${LDFLAGS} ${LIBDIR}\c0x32.obj $**, $@,,${LIBS}
+	${LD} ${LDFLAGS} ${LIBDIR}\c0x32.obj $^, $@,,${LIBS}
 
 defines.h: defines.wn
-	-del defines.h
-	-copy defines.wn defines.h
+	-@if EXIST "defines.h" del "defines.h" && echo "defines.h" removed
+	-copy defines.wn defines.h >NUL
 
 ${OBJ}: less.h defines.h funcs.h cmd.h
 
 clean:
-	-del *.obj
-	-del *.il?
-	-del *.tds
-	-del defines.h
-	-del less.exe
-	-del lesskey.exe
-	-del lessecho.exe
+	-@if EXIST "*.obj" del "*.obj" && echo "*.obj" removed
+	-@if EXIST "*.il?" del "*.il?" && echo "*.il?" removed
+	-@if EXIST "*.tds" del "*.tds" && echo "*.tds" removed
+	-@if EXIST "defines.h" del "defines.h" && echo "defines.h" removed
+	-@if EXIST "less.exe" del "less.exe" && echo "less.exe" removed
+	-@if EXIST "lessecho.exe" del "lessecho.exe" && echo "lessecho.exe" removed
+	-@if EXIST "lesskey.exe" del "lesskey.exe" && echo "lesskey.exe" removed
 
 build: all
 compile: ${OBJ}

--- a/Makefile.win.embcc
+++ b/Makefile.win.embcc
@@ -1,0 +1,105 @@
+# Makefile for less.
+# Windows version
+# Borland C++ 5.5.1 free command line tools
+
+# spell-checker:ignore (targets) distclean realclean vclean veryclean
+# spell-checker:ignore (make) abspath firstword ifeq ifndef ifneq lastword undefine vclean veryclean
+#
+# spell-checker:ignore (acronyms/names) Borland Borland's LLVM MSVC MinGW POSIX VCvars
+# spell-checker:ignore (flags/options) DDEBUG DNDEBUG NDEBUG Werror Wextra Xclang defaultlib dumpmachine flto flto-visibility-public-std libcmt nologo nothrow
+# spell-checker:ignore (jargon) multilib
+# spell-checker:ignore (shell/win) COMSPEC SystemDrive SystemRoot findstr findstring windir
+# spell-checker:ignore (utils) ilink nmake printf
+# spell-checker:ignore (vars) BQUOTE CFLAGS CPPFLAGS CXXFLAGS DEFINETYPE DQUOTE EXEEXT LDFLAGS LIBDIR LIBPATH MAKEDIR OBJDEP SHELLSTATUS devnull mkfile
+# spell-checker:ignore () brac cmdbuf forwback funcs ifile lessecho lesskey linenum lsystem optfunc opttbl stdext ttyin
+
+#### Start of system configuration section. ####
+#
+# Borland's make knows its own location in the
+# filesystem.
+#
+
+CC = embcc32
+LIBDIR := $(subst /,\,$(abspath $(firstword $(shell scoop which ${CC} 2>NUL) $(shell where ${CC} 2>NUL))\..\..\lib\win32c\release))
+LIBDIRS := "${LIBDIR}";"${LIBDIR}\psdk"
+
+# $(info LIBDIR=${LIBDIR})
+# $(info LIBDIRS=${LIBDIRS})
+
+# CFLAGS = -q -O2 -w-pro -TWC -P-c -v- -d -f- -ff- -vi
+CFLAGS = -q -O2 -TWC -P-c -v- -d -f- -vi
+LDFLAGS = -q -Tpe -v- -ap -c -x -V4.0 -GF:AGGRESSIVE -L${LIBDIRS}
+# LDFLAGS = -q -x -c -Gn -L${LIBDIRS}
+LD = ilink32
+# LIBS = "${LIBDIR}\import32.lib" "${LIBDIR}\cw32.lib"
+LIBS = import32.lib cw32.lib
+
+#### End of system configuration section. ####
+
+# # Set SHELL to `cmd` for Windows OS (note: environment/${OS}=="Windows_NT" for XP, 2000, Vista, 7, 10 ...)
+# # * `make` may otherwise use an incorrect shell (eg, `bash`), if found; "syntax error: unexpected end of file" error output is indicative
+# ifeq (${OS},Windows_NT)
+# 	# use case and location fallbacks; note: assumes *no spaces* within ${ComSpec}, ${SystemRoot}, or ${windir}
+# 	COMSPEC := $(or ${ComSpec},${COMSPEC},${comspec})
+# 	SystemRoot := $(or ${SystemRoot},${SYSTEMROOT},${systemroot},${windir})
+# 	SHELL := $(firstword $(wildcard ${COMSPEC} ${SystemRoot}/System32/cmd.exe) cmd)
+# endif
+# # $(info SHELL=${SHELL})
+
+####
+
+#
+# This rule allows us to supply the necessary -D options
+# in addition to whatever the user asks for.
+#
+# borland make
+.c.obj:
+	${CC} -c -I. ${CPPFLAGS} ${CFLAGS} $<
+# gnu make
+%.obj: %.c
+	${CC} -c -I. ${CPPFLAGS} ${CFLAGS} $<
+
+OBJ = \
+	main.obj screen.obj brac.obj ch.obj charset.obj cmdbuf.obj \
+	command.obj cvt.obj decode.obj edit.obj filename.obj forwback.obj \
+	help.obj ifile.obj input.obj jump.obj line.obj linenum.obj \
+	lsystem.obj mark.obj optfunc.obj option.obj opttbl.obj os.obj \
+	output.obj pattern.obj position.obj prompt.obj search.obj signal.obj \
+	tags.obj ttyin.obj version.obj regexp.obj
+
+all: less lesskey lessecho
+
+#
+# This is really horrible, but the command line is too long for
+# MS-DOS if we try to link ${OBJ}.
+#
+less: ${OBJ}
+#	${LD} ${LDFLAGS} "${LIBDIR}\c0x32.obj" ${OBJ} "${LIBDIR}\c0x32.obj", $@.exe,, ${LIBS}
+	${LD} ${LDFLAGS} "${LIBDIR}\c0x32.obj" ${OBJ}, $@.exe,, ${LIBS}
+
+lesskey: lesskey.obj version.obj
+	${LD} ${LDFLAGS} ${LIBDIR}\c0x32.obj $^, $@,,${LIBS}
+
+lessecho: lessecho.obj version.obj
+	${LD} ${LDFLAGS} ${LIBDIR}\c0x32.obj $^, $@,,${LIBS}
+
+defines.h: defines.wn
+	-del defines.h
+	-copy defines.wn defines.h
+
+${OBJ}: less.h defines.h funcs.h cmd.h
+
+clean:
+	-del *.obj
+	-del *.il?
+	-del *.tds
+	-del defines.h
+	-del less.exe
+	-del lesskey.exe
+	-del lessecho.exe
+
+build: all
+compile: ${OBJ}
+realclean: clean
+rebuild: clean build
+veryclean: realclean

--- a/Makefile.win.embcc
+++ b/Makefile.win.embcc
@@ -1,9 +1,12 @@
-# Makefile for less.
-# Windows version
-# Borland C++ 5.5.1 free command line tools
+# Makefile for `less`
+# `embcc32` (Embarcadero Borland C++ free command line tools); CMD/PowerShell host
+# GNU make (gmake) compatible; ref: <https://www.gnu.org/software/make/manual>
+# Copyright (C) 2020 ~ Roy Ivy III <rivy.dev@gmail.com>; MIT+Apache-2.0 license
 
+# spell-checker:ignore () INCDIRS LIBDIRS bcc32 embcc32 embcc psdk
+#
 # spell-checker:ignore (targets) distclean realclean vclean veryclean
-# spell-checker:ignore (make) abspath firstword ifeq ifndef ifneq lastword undefine vclean veryclean
+# spell-checker:ignore (make) abspath firstword gmake ifeq ifndef ifneq lastword undefine vclean veryclean
 #
 # spell-checker:ignore (acronyms/names) Borland Borland's LLVM MSVC MinGW POSIX VCvars
 # spell-checker:ignore (flags/options) DDEBUG DNDEBUG NDEBUG Werror Wextra Xclang defaultlib dumpmachine flto flto-visibility-public-std libcmt nologo nothrow
@@ -20,18 +23,17 @@
 #
 
 CC = embcc32
+LD = ilink32
+
 LIBDIR := $(subst /,\,$(abspath $(firstword $(shell scoop which ${CC} 2>NUL) $(shell where ${CC} 2>NUL))\..\..\lib\win32c\release))
 LIBDIRS := "${LIBDIR}";"${LIBDIR}\psdk"
-
-# $(info LIBDIR=${LIBDIR})
-# $(info LIBDIRS=${LIBDIRS})
 
 # CFLAGS = -q -O2 -w-pro -TWC -P-c -v- -d -f- -ff- -vi
 CFLAGS = -q -O2 -TWC -P-c -v- -d -f- -vi
 LDFLAGS = -q -Tpe -v- -ap -c -x -V4.0 -GF:AGGRESSIVE -L${LIBDIRS}
 # LDFLAGS = -q -x -c -Gn -L${LIBDIRS}
-LD = ilink32
-# LIBS = "${LIBDIR}\import32.lib" "${LIBDIR}\cw32.lib"
+
+LD_INIT_OBJ := ${LIBDIR}\c0x32.obj
 LIBS = import32.lib cw32.lib
 
 #### End of system configuration section. ####
@@ -48,14 +50,6 @@ LIBS = import32.lib cw32.lib
 
 ####
 
-#
-# This rule allows us to supply the necessary -D options
-# in addition to whatever the user asks for.
-#
-# borland make
-.c.obj:
-	${CC} -c -I. ${CPPFLAGS} ${CFLAGS} $<
-# gnu make
 %.obj: %.c
 	${CC} -c -I. ${CPPFLAGS} ${CFLAGS} $<
 
@@ -69,34 +63,29 @@ OBJ = \
 
 all: less lesskey lessecho
 
-#
-# This is really horrible, but the command line is too long for
-# MS-DOS if we try to link ${OBJ}.
-#
 less: ${OBJ}
-#	${LD} ${LDFLAGS} "${LIBDIR}\c0x32.obj" ${OBJ} "${LIBDIR}\c0x32.obj", $@.exe,, ${LIBS}
-	${LD} ${LDFLAGS} "${LIBDIR}\c0x32.obj" ${OBJ}, $@.exe,, ${LIBS}
+	${LD} ${LDFLAGS} ${LIB_INIT_OBJ} $^, $@,,${LIBS}
 
 lesskey: lesskey.obj version.obj
-	${LD} ${LDFLAGS} ${LIBDIR}\c0x32.obj $^, $@,,${LIBS}
+	${LD} ${LDFLAGS} ${LIB_INIT_OBJ} $^, $@,,${LIBS}
 
 lessecho: lessecho.obj version.obj
-	${LD} ${LDFLAGS} ${LIBDIR}\c0x32.obj $^, $@,,${LIBS}
+	${LD} ${LDFLAGS} ${LIB_INIT_OBJ} $^, $@,,${LIBS}
 
 defines.h: defines.wn
-	-del defines.h
-	-copy defines.wn defines.h
+	-@if EXIST "defines.h" del "defines.h" && echo "defines.h" removed
+	-copy defines.wn defines.h >NUL
 
 ${OBJ}: less.h defines.h funcs.h cmd.h
 
 clean:
-	-del *.obj
-	-del *.il?
-	-del *.tds
-	-del defines.h
-	-del less.exe
-	-del lesskey.exe
-	-del lessecho.exe
+	-@if EXIST "*.obj" del "*.obj" && echo "*.obj" removed
+	-@if EXIST "*.il?" del "*.il?" && echo "*.il?" removed
+	-@if EXIST "*.tds" del "*.tds" && echo "*.tds" removed
+	-@if EXIST "defines.h" del "defines.h" && echo "defines.h" removed
+	-@if EXIST "less.exe" del "less.exe" && echo "less.exe" removed
+	-@if EXIST "lessecho.exe" del "lessecho.exe" && echo "lessecho.exe" removed
+	-@if EXIST "lesskey.exe" del "lesskey.exe" && echo "lesskey.exe" removed
 
 build: all
 compile: ${OBJ}

--- a/defines.wn
+++ b/defines.wn
@@ -424,6 +424,10 @@
 #endif
 #endif
 
+#if (defined __BORLANDC__) && (__BORLANDC__ < 0x0600)
+#define popen _popen
+#endif
+
 #if (defined __clang__) && (!defined __GNUC__)
 /* fix: find a better way to add *user32.lib* (ie, *user32.dll*) for use of `MessageBeep()` in *screen.c* */
 /* see <https://stackoverflow.com/questions/9198787/how-do-i-compile-a-window-api-program-using-cl/9199083#9199083> @@ <https://archive.is/goUzN> */

--- a/defines.wn
+++ b/defines.wn
@@ -401,18 +401,27 @@
 #endif
 #endif
 
-#ifdef __clang__
+#if (defined __clang__) || ((defined __BORLANDC__) && (__BORLANDC__ >= 0x600))
 #define close   _close
 #define creat   _creat
-#define dup     _dup
 #define fileno  _fileno
+#define open    _open
+#define popen   _popen
+#define read    _read
+#define write   _write
+#ifndef __BORLANDC__
+#define dup     _dup
 #define isatty  _isatty
 #define lseek   _lseek
-#define open    _open
 #define putenv  _putenv
-#define read    _read
 #define setmode _setmode
-#define write   _write
+#else
+#define dup     dup
+#define isatty  isatty
+#define lseek   lseek
+#define putenv  putenv
+#define setmode setmode
+#endif
 #endif
 
 #if (defined __clang__) && (!defined __GNUC__)

--- a/less.h
+++ b/less.h
@@ -569,5 +569,8 @@ POSITION lstrtopos LESSPARAMS ((char*, char**));
 #ifndef _CRTIMP
 #define _CRTIMP
 #endif
+#ifndef __cdecl
+#define __cdecl
+#endif
 _CRTIMP int __cdecl pclose LESSPARAMS ((FILE*));
 #endif

--- a/less.h
+++ b/less.h
@@ -566,5 +566,8 @@ void inttoa LESSPARAMS ((int, char*));
 int lstrtoi LESSPARAMS ((char*, char**));
 POSITION lstrtopos LESSPARAMS ((char*, char**));
 #if MSDOS_COMPILER==WIN32C && !defined(MINGW)
+#ifndef _CRTIMP
+#define _CRTIMP
+#endif
 _CRTIMP int __cdecl pclose LESSPARAMS ((FILE*));
 #endif

--- a/output.c
+++ b/output.c
@@ -565,7 +565,7 @@ flush(VOID_PARAM)
                     }
                     if (!is_ansi_end(*p) || p == p_next)
                         break;
-                    /*                    /*
+                    /*
                      * In SGR mode, the ANSI sequence is
                      * always honored; otherwise if an attr
                      * is used by itself ("\e[1m" versus


### PR DESCRIPTION
Within msys2, for whatever reason, .exe is not being appended to the strip command. To circumvent this, .exe is removed from the variable if it exists, and then it is explicitly appended to the end of the command.

Additionally, the dev Makefile.win tries to check to make sure the compiler is valid. This seems to be a total shitshow if you are using ccache in msys2 (anything involving ccache in msys2 is a shitshow, truthfully).

It expects ccache.exe rather than ccache, and for some reason, even when you explicitly give it ccache.exe, the conditional operator will always interpret the return as false. So, I just found a variable that MSYS2 always uses and made it circumvent the error if it's detected - it's just not worth the time or effort to debug.